### PR TITLE
Add automated code quality checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 import pathlib
 
-from setuptools import find_packages, setup
+import setuptools
 
 PROJECT_ROOT = pathlib.Path(__file__).parent
 PROJECT_NAME = 'tvmaze'
@@ -34,14 +34,14 @@ PROJECT_KEYWORDS = [
     'metadata',
 ]
 
-setup(
+setuptools.setup(
     name=PROJECT_NAME,
     version=PROJECT_VERSION,
     license=PROJECT_LICENSE,
     description=PROJECT_DESCRIPTION,
     long_description=PROJECT_README.read_text('utf-8'),
     url=PROJECT_URL,
-    packages=find_packages(str(PROJECT_SOURCE_DIRECTORY)),
+    packages=setuptools.find_packages(str(PROJECT_SOURCE_DIRECTORY)),
     package_dir={
         '': str(PROJECT_SOURCE_DIRECTORY.relative_to(PROJECT_ROOT)),
     },

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding: utf-8 -*-
 
 """Distutils setup script for packaging and distribution."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ deps =
     flake8-import-order
     flake8-per-file-ignores
     flake8-tidy-imports
+    pep8-naming
 skip_install = true
 commands =
     flake8 --version

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ deps =
     flake8-pep3101
     flake8-per-file-ignores
     flake8-quotes
+    flake8-requirements
     flake8-self
     flake8-string-format
     flake8-tidy-imports

--- a/tox.ini
+++ b/tox.ini
@@ -20,12 +20,16 @@ commands =
 count = True
 statistics = True
 max-line-length = 79
+import-order-style = pycharm
+application-import-names = tvmaze
 no-accept-encodings = True
 
 [testenv:quality]
 deps =
     flake8
     flake8-coding
+    flake8-import-order
+    flake8-tidy-imports
 skip_install = true
 commands =
     flake8 --version

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     flake8-quotes
     flake8-string-format
     flake8-tidy-imports
+    hacking
     pep8-naming
 skip_install = true
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -28,10 +28,12 @@ inline-quotes = '
 multiline-quotes = '
 per-file-ignores =
     __init__.py: D104
+    tests/**: S101
 
 [testenv:quality]
 deps =
     flake8
+    flake8-bandit
     flake8-coding
     flake8-commas
     flake8-comprehensions

--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,7 @@ deps =
     flake8-pep3101
     flake8-per-file-ignores
     flake8-quotes
+    flake8-self
     flake8-string-format
     flake8-tidy-imports
     hacking

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ per-file-ignores =
 deps =
     flake8
     flake8-coding
+    flake8-commas
     flake8-docstrings
     flake8-import-order
     flake8-per-file-ignores

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps =
     flake8-self
     flake8-string-format
     flake8-tidy-imports
+    flake8-todo
     hacking
     pep8-naming
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -23,12 +23,16 @@ max-line-length = 79
 import-order-style = pycharm
 application-import-names = tvmaze
 no-accept-encodings = True
+per-file-ignores =
+    __init__.py: D104
 
 [testenv:quality]
 deps =
     flake8
     flake8-coding
+    flake8-docstrings
     flake8-import-order
+    flake8-per-file-ignores
     flake8-tidy-imports
 skip_install = true
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,28 @@
 
 [tox]
 envlist =
-    {py36,py37}
+    {py36,py37},
+    quality,
 
 [testenv]
 basepython =
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
+    quality: {env:TOXPYTHON:python3.6}
 deps =
     pytest
 commands =
     {posargs:pytest -vv tests}
+
+[flake8]
+count = True
+statistics = True
+max-line-length = 79
+
+[testenv:quality]
+deps =
+    flake8
+skip_install = true
+commands =
+    flake8 --version
+    flake8 src tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
     flake8
     flake8-bandit
     flake8-bugbear
+    flake8-builtins
     flake8-coding
     flake8-commas
     flake8-comprehensions

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,9 @@ max-line-length = 79
 import-order-style = pycharm
 application-import-names = tvmaze
 no-accept-encodings = True
+docstring-quotes = """
+inline-quotes = '
+multiline-quotes = '
 per-file-ignores =
     __init__.py: D104
 
@@ -33,7 +36,10 @@ deps =
     flake8-commas
     flake8-docstrings
     flake8-import-order
+    flake8-pep3101
     flake8-per-file-ignores
+    flake8-quotes
+    flake8-string-format
     flake8-tidy-imports
     pep8-naming
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,12 @@ commands =
 count = True
 statistics = True
 max-line-length = 79
+no-accept-encodings = True
 
 [testenv:quality]
 deps =
     flake8
+    flake8-coding
 skip_install = true
 commands =
     flake8 --version

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ deps =
     flake8
     flake8-coding
     flake8-commas
+    flake8-comprehensions
     flake8-docstrings
     flake8-import-order
     flake8-pep3101

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ per-file-ignores =
 deps =
     flake8
     flake8-bandit
+    flake8-bugbear
     flake8-coding
     flake8-commas
     flake8-comprehensions


### PR DESCRIPTION
Adding automated code quality checks helps to insure a consistent style across the project and can help to spot common code deficiencies.

Closes tvmaze/tvmaze#15 

Adds support for the following violation codes:

| CODE | DESCRIPTION |
| --- | --- |
A001 | variabel is a python builtin and is being shadowed
A002 | argument is used as an argument and thus shadows a python buuiltin
A003 | attribute is a python builtin
B001 | Do not use bare except. Disable E722 to avoid duplicate warnings.
B002 | Python does not support the unary prefix increment.
B003 | Assigning to `os.environ` doesn't clear the environment.
B004 | Using `hasattr(x, '__call__')` to test if `x` is callable is unreliable.
B005 | Using .strip() with multi-character strings is misleading the reader.
B006 | Do not use mutable data structures for argument defaults.
B007 | Loop control variable not used within the loop body.
B008 | Do not perform calls in argument defaults.
B301 | Python 3 does not include .iter* methods on dictionaries.
B302 | Python 3 does not include .view* methods on dictionaries.
B303 | Using `__metaclass__` on a class definition does nothing on Python 3.
B304 | `sys.maxint` is not a thing on Python 3. Use `sys.maxsize`.
B305 | `.next()` is not a thing on Python 3. Use the `next()` builtin.
B306 | `BaseException.message` is removed in Python 3.
B901 | Using `return x` in a generator function is invalid in Python 2.
B902 | Invalid first argument used for method. Use `self` or `cls`.
B903 | Use `namedtuple` for data classes that only set attributes
B950 | Line too long. Equivalent to pycodestyle's E501 but only warns if >10% longer.
C101 | Coding magic comment not found
C102 | Unknown encoding found in coding magic comment
C103 | Coding magic comment present
C400 | Unnecessary generator - rewrite as a list comprehension.
C401 | Unnecessary generator - rewrite as a set comprehension.
C402 | Unnecessary generator - rewrite as a dict comprehension.
C403 | Unnecessary list comprehension - rewrite as a set comprehension.
C404 | Unnecessary list comprehension - rewrite as a dict comprehension.
C405 | Unnecessary (list/tuple) literal - rewrite as a set literal.
C406 | Unnecessary (list/tuple) literal - rewrite as a dict literal.
C407 | Unnecessary list comprehension - '<builtin>' can take a generator.
C408 | Unnecessary (dict/list/tuple) call - rewrite as a literal.
C409 | Unnecessary (list/tuple) passed to `tuple()` - (remove the outer call to tuple()/rewrite as a tuple literal).
C410 | Unnecessary (list/tuple) passed to `list()` - (remove the outer call to list()/rewrite as a list literal).
C411 | Unnecessary list call - remove the outer call to `list()`.
C812 | missing trailing comma
C813 | missing trailing comma in Python 3
C814 | missing trailing comma in Python 2
C815 | missing trailing comma in Python 3.5+
C816 | missing trailing comma in Python 3.6+
C818 | trailing comma on bare tuple prohibited
C819 | trailing comma prohibited
C901 | name is too complex (comment)
D100 | Missing docstring in public module
D101 | Missing docstring in public class
D102 | Missing docstring in public method
D103 | Missing docstring in public function
D104 | Missing docstring in public package
D105 | Missing docstring in magic method
D106 | Missing docstring in public nested class
D107 | Missing docstring in `__init__`
D200 | One-line docstring should fit on one line with quotes
D201 | No blank lines allowed before function docstring
D202 | No blank lines allowed after function docstring
D203 | 1 blank line required before class docstring
D204 | 1 blank line required after class docstring
D205 | 1 blank line required between summary line and description
D206 | Docstring should be indented with spaces, not tabs
D207 | Docstring is under-indented
D208 | Docstring is over-indented
D209 | Multi-line docstring closing quotes should be on a separate line
D210 | No whitespaces allowed surrounding docstring text
D211 | No blank lines allowed before class docstring
D212 | Multi-line docstring summary should start at the first line
D213 | Multi-line docstring summary should start at the second line
D214 | Section is over-indented
D215 | Section underline is over-indented
D300 | Use “”“triple double quotes”“”
D301 | Use r”“” if any backslashes in a docstring
D302 | Use u”“” for Unicode docstrings
D400 | First line should end with a period
D401 | First line should be in imperative mood
D401 | First line should be in imperative mood; try rephrasing
D402 | First line should not be the function’s “signature”
D403 | First word of the first line should be properly capitalized
D404 | First word of the docstring should not be This
D405 | Section name should be properly capitalized
D406 | Section name should end with a newline
D407 | Missing dashed underline after section
D408 | Section underline should be in the line following the section’s name
D409 | Section underline should match the length of its name
D410 | Missing blank line after section
D411 | Missing blank line before section
D412 | No blank lines allowed between a section header and its content
D413 | Missing blank line after last section
D414 | Section has no content
E1 | Indentation
E101 | indentation contains mixed spaces and tabs
E111 | indentation is not a multiple of four
E112 | expected an indented block
E113 | unexpected indentation
E114 | indentation is not a multiple of four (comment)
E115 | expected an indented block (comment)
E116 | unexpected indentation (comment)
E121 | continuation line under-indented for hanging indent
E122 | continuation line missing indentation or outdented
E123 | closing bracket does not match indentation of opening bracket’s line
E124 | closing bracket does not match visual indentation
E125 | continuation line with same indent as next logical line
E126 | continuation line over-indented for hanging indent
E127 | continuation line over-indented for visual indent
E128 | continuation line under-indented for visual indent
E129 | visually indented line with same indent as next logical line
E131 | continuation line unaligned for hanging indent
E133 | closing bracket is missing indentation
E2 | Whitespace
E201 | whitespace after ‘(‘
E202 | whitespace before ‘)’
E203 | whitespace before ‘:’
E211 | whitespace before ‘(‘
E221 | multiple spaces before operator
E222 | multiple spaces after operator
E223 | tab before operator
E224 | tab after operator
E225 | missing whitespace around operator
E226 | missing whitespace around arithmetic operator
E227 | missing whitespace around bitwise or shift operator
E228 | missing whitespace around modulo operator
E231 | missing whitespace after ‘,’, ‘;’, or ‘:’
E241 | multiple spaces after ‘,’
E242 | tab after ‘,’
E251 | unexpected spaces around keyword / parameter equals
E261 | at least two spaces before inline comment
E262 | inline comment should start with ‘# ‘
E265 | block comment should start with ‘# ‘
E266 | too many leading ‘#’ for block comment
E271 | multiple spaces after keyword
E272 | multiple spaces before keyword
E273 | tab after keyword
E274 | tab before keyword
E275 | missing whitespace after keyword
E3 | Blank line
E301 | expected 1 blank line, found 0
E302 | expected 2 blank lines, found 0
E303 | too many blank lines (3)
E304 | blank lines found after function decorator
E305 | expected 2 blank lines after end of function or class
E306 | expected 1 blank line before a nested definition
E4 | Import
E401 | multiple imports on one line
E402 | module level import not at top of file
E5 | Line length
E501 | line too long (82 > 79 characters)
E502 | the backslash is redundant between brackets
E7 | Statement
E701 | multiple statements on one line (colon)
E702 | multiple statements on one line (semicolon)
E703 | statement ends with a semicolon
E704 | multiple statements on one line (def)
E711 | comparison to None should be ‘if cond is None:’
E712 | comparison to True should be ‘if cond is True:’ or ‘if cond:’
E713 | test for membership should be ‘not in’
E714 | test for object identity should be ‘is not’
E721 | do not compare types, use ‘isinstance()’
E722 | do not use bare except, specify exception instead
E731 | do not assign a lambda expression, use a def
E741 | do not use variables named ‘l’, ‘O’, or ‘I’
E742 | do not define classes named ‘l’, ‘O’, or ‘I’
E743 | do not define functions named ‘l’, ‘O’, or ‘I’
E9 | Runtime
E901 | SyntaxError or IndentationError
E902 | IOError
E999 | Failed to compile a file into an Abstract Syntax Tree
F401 | module imported but unused
F402 | import module from line N shadowed by loop variable
F403 | ‘from module import *’ used; unable to detect undefined names
F404 | future import(s) name after other statements
F405 | name may be undefined, or defined from star imports: module
F406 | ‘from module import *’ only allowed at module level
F407 | an undefined `__future__` feature name was imported
F601 | dictionary key name repeated with different values
F602 | dictionary key variable name repeated with different values
F621 | too many expressions in an assignment with star-unpacking
F622 | two or more starred expressions in an assignment (a, *b, *c = d)
F631 | assertion test is a tuple, which are always True
F701 | a break statement outside of a while or for loop
F702 | a continue statement outside of a while or for loop
F703 | a continue statement in a finally block in a loop
F704 | a yield or yield from statement outside of a function
F705 | a return statement with arguments inside a generator
F706 | a return statement outside of a function/method
F707 | an except: block as not the last exception handler
F811 | redefinition of unused name from line N
F812 | list comprehension redefines name from line N
F821 | undefined name name
F822 | undefined name name in `__all__`
F823 | local variable name … referenced before assignment
F831 | duplicate argument name in function definition
F841 | local variable name is assigned to but never used
H101 | Include your name with TODOs as in # TODO(yourname)
H102-H103 | Newly contributed Source Code should be licensed under Apache 2.0
H104 | Files with no code shouldn't contain any license header nor comments, and must be left completely empty.
H105 | Don't use author tags. We use version control instead.
H106 | Don't put vim configuration in source files (off by default).
H201 | Do not write except:, use except Exception: at the very least.
H202 | Use assertRaises instead of testing for Exception
H203 | Use assertIs(Not)None to check for None (off by default)
H204 | Use assert(Not)Equal to check for equality (off by default)
H205 | Use assert(Greater|Less)(Equal) for comparison (off by default)
H210 | Require autospec, spec, or spec_set in mock.patch() or mock.patch.object() calls (off by default)
H231 | Instead of `except x,y` use `except x as y`
H232 | Octal string literals require explicit octal prefix
H233 | Use print as a function
H234 | assertEquals() is deprecated in Python 3.x, use assertEqual()
H235 | assert_() is deprecated in Python 3.x, use assertTrue() instead
H236 | Use six.add_metaclass instead of `__metaclass__`.
H237 | Don't use modules that were removed in Python 3
H238 | Old style classes are deprecated and no longer available in Python 3
H301 | Do not import more than one module per line (*)
H303 | Do not use wildcard * import (*)
H304 | Do not make relative imports
H306 | Alphabetically order your imports by the full module path.
H401 | Docstrings should not start with a space.
H403 | Multi line docstrings should end on a new line.
H404 | Multi line docstrings should start without a leading new line.
H405 | Multi line docstrings should start with a one line summary	followed by an empty line.
H501 | Do not use locals() or `self.__dict__` for formatting strings.
H702 | If you have a variable to place within the string, first internationalize the template string then do the replacement.
H703 | If you have multiple variables to place in the string, use keyword parameters. This helps translators reorder parameters when needed.
H903 | Use only UNIX style newlines (\n), not Windows style (\r\n)
H904 | Delay string interpolations at logging calls (off by default).
I100 | Your import statements are in the wrong order.
I101 | The names in your from import are in the wrong order.
I200 | Unnecessary import alias
I201 | Missing newline between import groups.
I202 | Additional newline in a group of imports.
I201 | Banned import 'foo' used
I900 | Package is not listed as a requirement.
I901 | Package is require but not used.
N801 | class names should use CapWords convention
N802 | function name should be lowercase
N803 | argument name should be lowercase
N804 | first argument of a classmethod should be named 'cls'
N805 | first argument of a method should be named 'self'
N806 | variable in function should be lowercase
N807 | function name should not start or end with '__'
N811 | constant imported as non constant
N812 | lowercase imported as non lowercase
N813 | camelcase imported as lowercase
N814 | camelcase imported as constant
N815 | mixedCase variable in class scope
N816 | mixedCase variable in global scope
P101 | format string does contain unindexed parameters
P102 | docstring does contain unindexed parameters
P103 | other string does contain unindexed parameters
P201 | format call uses to large index (INDEX)
P202 | format call uses missing keyword (KEYWORD)
P203 | format call uses keyword arguments but no named entries
P204 | format call uses variable arguments but no numbered entries
P205 | format call uses implicit and explicit indexes together
P301 | format call provides unused index (INDEX)
P302 | format call provides unused keyword (KEYWORD)
S001 | found modulo formatter
S101 | assert_used
S102 | exec_used
S103 | set_bad_file_permissions
S104 | hardcoded_bind_all_interfaces
S105 | hardcoded_password_string
S106 | hardcoded_password_funcarg
S107 | hardcoded_password_default
S108 | hardcoded_tmp_directory
S109 | password_config_option_not_marked_secret
S110 | try_except_pass
S111 | execute_with_run_as_root_equals_true
S112 | try_except_continue
S201 | flask_debug_true
S301 | pickle
S302 | marshal
S303 | md5
S304 | ciphers
S305 | cipher_modes
S306 | mktemp_q
S307 | eval
S308 | mark_safe
S309 | httpsconnection
S310 | urllib_urlopen
S311 | random
S312 | telnetlib
S313 | xml_bad_cElementTree
S314 | xml_bad_ElementTree
S315 | xml_bad_expatreader
S316 | xml_bad_expatbuilder
S317 | xml_bad_sax
S318 | xml_bad_minidom
S319 | xml_bad_pulldom
S320 | xml_bad_etree
S321 | ftplib
S322 | input
S323 | unverified_context
S324 | hashlib_new_insecure_functions
S401 | import_telnetlib
S402 | import_ftplib
S403 | import_pickle
S404 | import_subprocess
S405 | import_xml_etree
S406 | import_xml_sax
S407 | import_xml_expat
S408 | import_xml_minidom
S409 | import_xml_pulldom
S410 | import_lxml
S411 | import_xmlrpclib
S412 | import_httpoxy
S413 | import_pycrypto
S414 | import_pycryptodome
S501 | request_with_no_cert_validation
S502 | ssl_with_bad_version
S503 | ssl_with_bad_defaults
S504 | ssl_with_no_version
S505 | weak_cryptographic_key
S506 | yaml_load
S601 | paramiko_calls
S602 | subprocess_popen_with_shell_equals_true
S603 | subprocess_without_shell_equals_true
S604 | any_other_function_with_shell_equals_true
S605 | start_process_with_a_shell
S606 | start_process_with_no_shell
S607 | start_process_with_partial_path
S608 | hardcoded_sql_expressions
S609 | linux_commands_wildcard_injection
S610 | django_extra_used
S611 | django_rawsql_used
S701 | jinja2_autoescape_false
S702 | use_of_mako_templates
S703 | django_mark_safe
SF01 | Private member access
T000 | Todo note found.
Q000 | Remove bad quotes
Q001 | Remove bad quotes from multiline string
Q002 | Remove bad quotes from docstring
W1 | Indentation warning
W191 | indentation contains tabs
W2 | Whitespace warning
W291 | trailing whitespace
W292 | no newline at end of file
W293 | blank line contains whitespace
W3 | Blank line warning
W391 | blank line at end of file
W5 | Line break warning
W503 | line break before binary operator
W504 | line break after binary operator
W505 | doc line too long (82 > 79 characters)
W6 | Deprecation warning
W601 | .has_key() is deprecated, use ‘in’
W602 | deprecated form of raising exception
W603 | ‘<>’ is deprecated, use ‘!=’
W604 | backticks are deprecated, use ‘repr()’
W605 | invalid escape sequence ‘x’
W606 | ‘async’ and ‘await’ are reserved keywords starting with Python 3.7
