### PR TITLE
Fix code-quality checks not running on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
-  matrix:
-    - TOXENV=quality
 matrix:
   include:
+    - python: '3.6'
+      env:
+        - TOXENV=quality
     - python: '3.6'
       env:
         - TOXENV=py36,covered,coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ ignore =
 ;   H405 multi line docstring summary not separated with an empty line
     H404, H405,
 per-file-ignores =
-    __init__.py: D104
     tests/**: S101
 
 [testenv:quality]

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ ignore =
 ;   H405 multi line docstring summary not separated with an empty line
     H404, H405,
 per-file-ignores =
+;   S101 Use of assert detected
     tests/**: S101
 
 [testenv:quality]


### PR DESCRIPTION
Code quality checks were skipped when running tests on Travis.

Also removes unnecessary `D104` ignore and adds a missed comment on `S101`.