### PR TITLE
Fix version tagging

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.2.0
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:setup.py]
 search = PROJECT_VERSION = '{current_version}'


### PR DESCRIPTION
Fix bumpversion tagging so tags are created manually upon release

This ensures the tag is actually on the Master branch and not the deleted release branch.